### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-contrib-watch": "~0.6.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.4"
+    "grunt": ">=0.4.4"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Description nicked from @gruntjs–updater

> Hello,
> 
> This is an automated issue request to update the peerDependencies for your Grunt plugin.
> We ask you to merge this and publish a new release on npm to get your plugin working in Grunt 1.0!
> 
> Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
> Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392
> 
> If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.
> 
> Thanks for creating and working on this plugin!
> 
> (P.S. Close this PR if it is a mistake, sorry)

Otherwise, this plugin will fail to install when using Grunt 1.0:

```
npm ERR! peerinvalid Peer grunt-xml-validator@1.1.2 wants grunt@~0.4.4
```
